### PR TITLE
Move type declerations to d.ts files

### DIFF
--- a/client/src/components/AuthTestForm.tsx
+++ b/client/src/components/AuthTestForm.tsx
@@ -1,22 +1,10 @@
 import React, { useState, useEffect } from "react";
-import { StyledHomeForm } from "../styles/componentStyles/HomeFormStyles";
 import { logIn, signUp, getCurrentUser, logOut } from "../services/auth";
-
-type RegisterFormData = {
-  username: string;
-  email: string;
-  password: string;
-};
 
 const initialRegisterFormData: RegisterFormData = {
   username: "",
   email: "",
   password: "",
-};
-
-type LoginFormData = {
-  usernameOrEmail: string;
-  password: string;
 };
 
 const initialLoginFormData: LoginFormData = {
@@ -25,17 +13,12 @@ const initialLoginFormData: LoginFormData = {
 };
 
 const AuthTestForm = () => {
-  const [registerFormData, setRegisterFormData] = useState<RegisterFormData>(
-    initialRegisterFormData
-  );
-
-  const [loginFormData, setLoginFormData] =
-    useState<LoginFormData>(initialLoginFormData);
-
+  const [registerFormData, setRegisterFormData] = useState<RegisterFormData>(initialRegisterFormData);
+  const [loginFormData, setLoginFormData] = useState<LoginFormData>(initialLoginFormData);
   const [currentUser, setCurrentUser] = useState<any>();
 
   const handleRegisterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setRegisterFormData((prev) => {
+    setRegisterFormData(prev => {
       return {
         ...prev,
         [e.target.name]: e.target.value,
@@ -44,7 +27,7 @@ const AuthTestForm = () => {
   };
 
   const handleLoginChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLoginFormData((prev) => {
+    setLoginFormData(prev => {
       return {
         ...prev,
         [e.target.name]: e.target.value,
@@ -54,26 +37,20 @@ const AuthTestForm = () => {
 
   const handleRegisterSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    signUp(
-      registerFormData.email,
-      registerFormData.username,
-      registerFormData.password
-    ).then((user) => {
+    signUp(registerFormData.email, registerFormData.username, registerFormData.password).then(user => {
       setCurrentUser(user);
     });
   };
 
   const handleLoginSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    logIn(loginFormData.usernameOrEmail, loginFormData.password).then(
-      (user) => {
-        setCurrentUser(user);
-      }
-    );
+    logIn(loginFormData.usernameOrEmail, loginFormData.password).then(user => {
+      setCurrentUser(user);
+    });
   };
 
   useEffect(() => {
-    getCurrentUser().then((user) => {
+    getCurrentUser().then(user => {
       setCurrentUser(user);
     });
   }, []);
@@ -92,46 +69,21 @@ const AuthTestForm = () => {
         </button>
       </div>
       <div>
-        <form spellCheck="false" onSubmit={handleRegisterSubmit}>
+        <form spellCheck='false' onSubmit={handleRegisterSubmit}>
           <h1>SIGN UP</h1>
-          <input
-            name="username"
-            type="text"
-            placeholder="Username"
-            onChange={handleRegisterChange}
-          />
-          <input
-            name="email"
-            type="email"
-            placeholder="Email"
-            onChange={handleRegisterChange}
-          />
-          <input
-            name="password"
-            type="password"
-            placeholder="Choose your password"
-            onChange={handleRegisterChange}
-          />
-          <button type="submit">Sign Up</button>
+          <input name='username' type='text' placeholder='Username' onChange={handleRegisterChange} />
+          <input name='email' type='email' placeholder='Email' onChange={handleRegisterChange} />
+          <input name='password' type='password' placeholder='Choose your password' onChange={handleRegisterChange} />
+          <button type='submit'>Sign Up</button>
         </form>
       </div>
 
       <div>
-        <form spellCheck="false" onSubmit={handleLoginSubmit}>
+        <form spellCheck='false' onSubmit={handleLoginSubmit}>
           <h1>LOG IN</h1>
-          <input
-            name="usernameOrEmail"
-            type="text"
-            placeholder="Username or Email"
-            onChange={handleLoginChange}
-          />
-          <input
-            name="password"
-            type="password"
-            placeholder="Enter your password"
-            onChange={handleLoginChange}
-          />
-          <button type="submit">Log In</button>
+          <input name='usernameOrEmail' type='text' placeholder='Username or Email' onChange={handleLoginChange} />
+          <input name='password' type='password' placeholder='Enter your password' onChange={handleLoginChange} />
+          <button type='submit'>Log In</button>
         </form>
       </div>
     </>

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,22 +1,8 @@
-import React, { AnchorHTMLAttributes } from 'react';
-import { Link } from 'react-router-dom';
-import { StyledButton } from '../styles/componentStyles/ButtonStyles';
+import React from "react";
+import { Link } from "react-router-dom";
+import { StyledButton } from "../styles/componentStyles/ButtonStyles";
 
-interface IButtonProps {
-  buttonText: string;
-  isLinkButton: boolean;
-  link: string;
-  target?: string;
-  rel?: string;
-}
-
-const Button: React.FC<IButtonProps> = ({
-  buttonText,
-  isLinkButton,
-  link,
-  target,
-  rel,
-}) => {
+const Button: React.FC<IButtonProps> = ({ buttonText, isLinkButton, link, target, rel }) => {
   return (
     <StyledButton>
       {isLinkButton ? (

--- a/client/src/components/HomeForm.tsx
+++ b/client/src/components/HomeForm.tsx
@@ -4,12 +4,6 @@ import { signUp } from "../services/auth";
 
 interface IHomeFormProps {}
 
-type FormData = {
-  username: string;
-  email: string;
-  password: string;
-};
-
 const initialFormData = {
   username: "",
   email: "",
@@ -17,10 +11,10 @@ const initialFormData = {
 };
 
 const HomeForm: React.FC<IHomeFormProps> = ({}) => {
-  const [formData, setFormData] = useState<FormData>(initialFormData);
+  const [formData, setFormData] = useState<FormInput>(initialFormData);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData((prev) => {
+    setFormData(prev => {
       return {
         ...prev,
         [e.target.name]: e.target.value,
@@ -35,28 +29,13 @@ const HomeForm: React.FC<IHomeFormProps> = ({}) => {
 
   return (
     <StyledHomeForm>
-      <form spellCheck="false" onSubmit={handleSubmit}>
+      <form spellCheck='false' onSubmit={handleSubmit}>
         <h1>SIGN UP</h1>
         <p>Never forget for a Better Tomorrow</p>
-        <input
-          name="username"
-          type="text"
-          placeholder="Username"
-          onChange={handleChange}
-        />
-        <input
-          name="email"
-          type="email"
-          placeholder="Email"
-          onChange={handleChange}
-        />
-        <input
-          name="password"
-          type="password"
-          placeholder="Choose your password"
-          onChange={handleChange}
-        />
-        <button type="submit">Sign Up</button>
+        <input name='username' type='text' placeholder='Username' onChange={handleChange} />
+        <input name='email' type='email' placeholder='Email' onChange={handleChange} />
+        <input name='password' type='password' placeholder='Choose your password' onChange={handleChange} />
+        <button type='submit'>Sign Up</button>
       </form>
     </StyledHomeForm>
   );

--- a/client/src/configs/StaticData.ts
+++ b/client/src/configs/StaticData.ts
@@ -1,12 +1,10 @@
-import { INavLinks } from '../typings/StaticDataTypes';
-
 export const navLinks: INavLinks[] = [
   {
-    name: 'About us',
-    url: '#about',
+    name: "About us",
+    url: "#about",
   },
   {
-    name: 'Contact',
-    url: '#contact',
+    name: "Contact",
+    url: "#contact",
   },
 ];

--- a/client/src/typings/StaticDataTypes.ts
+++ b/client/src/typings/StaticDataTypes.ts
@@ -1,4 +1,0 @@
-export interface INavLinks {
-  name: string;
-  url: string;
-}

--- a/client/src/typings/main.d.ts
+++ b/client/src/typings/main.d.ts
@@ -1,0 +1,17 @@
+interface INavLinks {
+  name: string;
+  url: string;
+}
+
+interface FormInput {
+  username: string;
+  email: string;
+  password: string;
+}
+
+interface RegisterFormData extends FormInput {}
+
+interface LoginFormData {
+  usernameOrEmail: string;
+  password: string;
+}

--- a/client/src/typings/props.d.ts
+++ b/client/src/typings/props.d.ts
@@ -1,0 +1,7 @@
+interface IButtonProps {
+  buttonText: string;
+  isLinkButton: boolean;
+  link: string;
+  target?: string;
+  rel?: string;
+}


### PR DESCRIPTION
this way, we don't need to export `interfaces/types` nor import them. I made two declaration files; `main.d.ts` (*for types other than prop types*) & `props.d.ts` (*for prop types*)

`📂 src`
&nbsp;&nbsp; ↳ `📂 typings`
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ↳ `📄 main.d.ts` 
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ↳ `📄 props.d.ts`

EDIT: my prettier extension changed the structure of some files, sry for that ✌